### PR TITLE
Remove Google+ link

### DIFF
--- a/index.html
+++ b/index.html
@@ -190,8 +190,6 @@
         |
         <a href="https://www.facebook.com/kontalknet" title="Follow us on Facebook!">Facebook page</a>
         |
-        <a href="https://plus.google.com/102201749813756709299" title="Follow us on Google+!">Google+ page</a>
-        |
         <a href="https://www.kontalk.org/" title="Home of the Kontalk project">Project home</a>
 
     </div>


### PR DESCRIPTION
Google+ is dead. Let's remove the link.

Closes https://github.com/kontalk/website.net/issues/1